### PR TITLE
API documentation: added table.delete()

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -16,7 +16,7 @@ Table
 -----
 
 .. autoclass:: dataset.Table
-   :members: columns, find, find_one, all, distinct, insert, insert_many, update, upsert,   create_column, create_index, drop
+   :members: columns, find, find_one, all, distinct, insert, insert_many, update, upsert,   delete, create_column, create_index, drop
    :special-members: __len__, __iter__
 
 


### PR DESCRIPTION
Just noticed that the documentation don't have the `table.delete()` method on it.
