### PR TITLE
Don't modify the root logger if being used as a library

### DIFF
--- a/dataset/freeze/app.py
+++ b/dataset/freeze/app.py
@@ -8,7 +8,6 @@ from dataset.freeze.config import Configuration, Export
 from dataset.freeze.format import get_serializer
 
 
-logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger(__name__)
 
 parser = argparse.ArgumentParser(
@@ -104,4 +103,5 @@ def main():
         log.error(fe)
 
 if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
     main()


### PR DESCRIPTION
Libraries in python mustn't interfere with the root logger - only applications should do this.

I've moved the line:

```
logging.basicConfig()
```

so that it is only called if we're using app.py as an application.

This allows verbose logging when running **python app.py** without breaking logging in other applications relying on dataset.
