### PR TITLE
allow keys arg for upsert to be a string

### DIFF
--- a/dataset/persistence/table.py
+++ b/dataset/persistence/table.py
@@ -147,6 +147,10 @@ class Table(object):
             data = dict(id=10, title='I am a banana!')
             table.upsert(data, ['id'])
         """
+        # check whether keys arg is a string and format as a list
+        if isinstance(keys, basestring):
+            keys = [keys]
+            
         self._check_dropped()
         if ensure:
             self.create_index(keys)


### PR DESCRIPTION
I want to be able to use `upsert` without formatting the keys arg as a list, ie:

```
table.upsert(new_data, "id")
```
