### PR TITLE
Fix insert for tables that do not have any primary key.

### DIFF
--- a/dataset/persistence/table.py
+++ b/dataset/persistence/table.py
@@ -68,7 +68,8 @@ class Table(object):
         if ensure:
             self._ensure_columns(row, types=types)
         res = self.database.executable.execute(self.table.insert(row))
-        return res.inserted_primary_key[0]
+        if len(res.inserted_primary_key) > 0:
+            return res.inserted_primary_key[0]
 
     def insert_many(self, rows, chunk_size=1000, ensure=True, types={}):
         """


### PR DESCRIPTION
The insert method returns the value of the primary key for the inserted
row. But for tables that do not have any primary key, it raises an
IndexError, which is clearly wrong. At best it should return None in
such cases and avoid raising any exception.
