### PR TITLE
set _limit to total_row_count if it is None

### DIFF
--- a/dataset/persistence/table.py
+++ b/dataset/persistence/table.py
@@ -337,6 +337,9 @@ class Table(object):
         rp = self.database.executable.execute(count_query)
         total_row_count = rp.fetchone()[0]
 
+        if _limit is None:
+            _limit = total_row_count
+
         if _step is None or _step is False or _step == 0:
             _step = total_row_count
 


### PR DESCRIPTION
In `table.find()` function, if `_limit` is `None`, the last `for` loop will never stop. One solution is to set it the value of `total_row_count`.

This fixed #67.
