### PR TITLE
add 'build' to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 *.egg-info
 dist/*
+build/*
 .DS_Store
 .watchr
 


### PR DESCRIPTION
To ignore `build` subdictionary which is created when installing `dataset`
