### PR TITLE
Negate operators

### DIFF
--- a/dataset/persistence/table.py
+++ b/dataset/persistence/table.py
@@ -202,11 +202,21 @@ class Table(object):
     def _args_to_clause(self, args):
         self._ensure_columns(args)
         clauses = []
+        negate_flag = False
         for k, v in args.items():
-            if isinstance(v, (list, tuple)):
-                clauses.append(self.table.c[k].in_(v))
+            if k == 'negate_flag' and v:
+                negate_flag = True
+                continue
+            if negate_flag:
+                if isinstance(v, (list, tuple)):
+                    clauses.append(self.table.c[k].notin_(v))
+                else:
+                    clauses.append(self.table.c[k] != v)
             else:
-                clauses.append(self.table.c[k] == v)
+                if isinstance(v, (list, tuple)):
+                    clauses.append(self.table.c[k].in_(v))
+                else:
+                    clauses.append(self.table.c[k] == v)
         return and_(*clauses)
 
     def create_column(self, name, type):


### PR DESCRIPTION
Hi,
I saw that I couldn't use dataset to make a WHERE foo <> bar, so I thought it could be done with a parameter to negate all what comes after it.

It would be used like this:

    table.find(negate_flag=True, foo='bar')
    # SELECT * FROM table WHERE foo <> 'bar'
    table.find(foo='foo',negate_flag=True, foo='bar')
    # SELECT * FROM table WHERE foo = 'foo' AND foo <> 'bar'

I don't like the parameter name, but I can't think of any better at the moment.

What do you think?
