### PR TITLE
Release all the locks acquired by transaction on commit/rollback

### DIFF
--- a/dataset/persistence/database.py
+++ b/dataset/persistence/database.py
@@ -70,22 +70,22 @@ class Database(object):
     def _release(self):
         if not hasattr(self.local, 'tx'):
             self.lock.release()
-            self.local.must_release = False
         else:
-            self.local.must_release = True
+            self.local.lock_count[-1] += 1
 
     def _release_internal(self):
-        if getattr(self.local, 'must_release', None):
+        for index in range(self.local.lock_count[-1]):
             self.lock.release()
-            self.local.must_release = False
+        del self.local.lock_count[-1]
 
     def _dispose_transaction(self):
+        self._release_internal()
         self.local.tx.remove(self.local.tx[-1])
         if not self.local.tx:
             del self.local.tx
+            del self.local.lock_count
             self.local.connection.close()
             del self.local.connection
-            self._release_internal()
 
     def begin(self):
         """ Enter a transaction explicitly. No data will be written
@@ -97,7 +97,9 @@ class Database(object):
             self.local.connection = self.engine.connect()
         if not hasattr(self.local, 'tx'):
             self.local.tx = []
+            self.local.lock_count = []
         self.local.tx.append(self.local.connection.begin())
+        self.local.lock_count.append(0)
 
     def commit(self):
         """ Commit the current transaction, making all statements executed


### PR DESCRIPTION
https://docs.python.org/2/library/threading.html#rlock-objects

```
threading.RLock()
A factory function that returns a new reentrant lock object. A reentrant lock must be released by the thread that acquired it. Once a thread has acquired a reentrant lock, the same thread may acquire it again without blocking; the thread must release it once for each time it has acquired it.
```

In dataset, it will hold all the release operations util transaction commit/rollback, but it `only call the release() once`.
A sample code to reproduce the problem of reentrant lock.
```
import threading
import time

lock = threading.RLock()
lock.acquire()
lock.acquire()
lock.release() # It still holds the lock!!!

def test():
    print 'start'
    lock.acquire()
    print 'end'
    lock.release()

t = threading.Thread(target=test)
t.start()

time.sleep(5)
lock.release()
```
