### PR TITLE
Simple change in table.py to return query from find

### DIFF
--- a/dataset/persistence/table.py
+++ b/dataset/persistence/table.py
@@ -365,6 +365,7 @@ class Table(object):
         _step = kwargs.pop('_step', 5000)
         order_by = kwargs.pop('order_by', 'id')
         return_count = kwargs.pop('return_count', False)
+        return_query = kwargs.pop('return_query', False)
         _filter = kwargs
 
         self._check_dropped()
@@ -391,6 +392,8 @@ class Table(object):
 
         query = self.table.select(whereclause=args, limit=_limit,
                                   offset=_offset, order_by=order_by)
+        if return_query:
+            return query
         return ResultIter(self.database.executable.execute(query),
                           row_type=self.database.row_type, step=_step)
 


### PR DESCRIPTION
This is a simple return_ hook to return the selectable instead of the result from table.find.
This is helpful if you want to load the data using sqlalchemy, or something that supports sqlalchemy (such as pandas).

Example:

```
import dataset
import pandas as pd
db = dataset.connect('sqlite:///mydatabase.db')
table=db['user']
table.delete() #clear the table a fresh dev env
table.insert(dict(name='John Doe', age=46, country='China'))
table.insert(dict(name='John Doe', age=19, country='USA'))
table.insert(dict(name='Jane Doe', age=37, country='France', gender='female'))
print(pd.read_sql("user",db.engine))
#   id country  age      name  gender
#0   1   China   46  John Doe    None
#1   2     USA   19  John Doe    None
#2   3  France   37  Jane Doe  female

q=table.find(name="John Doe",return_query=True)
print(pd.read_sql_query(qu,db.engine))
#   id country  age      name gender
#0   1   China   46  John Doe   None
#1   2     USA   19  John Doe   None
```