### PR TITLE
Let users pass `unique` boolean to .create_index

### DIFF
--- a/dataset/persistence/table.py
+++ b/dataset/persistence/table.py
@@ -323,7 +323,7 @@ class Table(object):
         finally:
             self.database._release()
 
-    def create_index(self, columns, name=None):
+    def create_index(self, columns, name=None, unique=False):
         """
         Create an index to speed up queries on a table.
 
@@ -351,7 +351,7 @@ class Table(object):
         try:
             self.database._acquire()
             columns = [self.table.c[c] for c in columns]
-            idx = Index(name, *columns)
+            idx = Index(name, *columns, unique=unique)
             idx.create(self.database.engine)
         except:
             idx = None


### PR DESCRIPTION
Thank you for this insanely useful library. It's a total delight to use. This PR explicitly passes the `unique` keyword to `sqlalchemy.schema.Index`; alternatively, I could take a broader/less-specific approach of having `Table.create_index` accepting `**kw` and passing that to `sqlalchemy.schema.Index`.