### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ dataset: databases for lazy people
 
 In short, **dataset** makes reading and writing data in databases as simple as reading and writing JSON files.
 
-[Read the docs](https://dataset.readthedocs.org/)
+[Read the docs](https://dataset.readthedocs.io/)
 
 To install dataset, fetch it with ``pip``:
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.