### PR TITLE
bug fix, make Table.drop_column be aware of table schema

### DIFF
--- a/dataset/persistence/table.py
+++ b/dataset/persistence/table.py
@@ -326,7 +326,8 @@ class Table(object):
             if name in self.table.columns.keys():
                 self.database.op.drop_column(
                     self.table.name,
-                    name
+                    name,
+                    self.table.schema
                 )
                 self.table = self.database.update_table(self.table.name)
         finally:


### PR DESCRIPTION
if don't pass in schema here, it will be None by default.
Fix it to be aware of schema like Table.create_column.