### PR TITLE
handle Decimal class as a string to avoid "null" as returned value

### DIFF
--- a/dataset/freeze/format/fjson.py
+++ b/dataset/freeze/format/fjson.py
@@ -12,6 +12,8 @@ class JSONEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, (datetime, date)):
             return obj.isoformat()
+        if isinstance(obj, Decimal):
+            return str(obj)
 
 
 class JSONSerializer(Serializer):


### PR DESCRIPTION
Hi,

This fix is needed to handle Decimal() type. If not, a 'null' value is returned. The value I'm working with:

Please find below the behavior I noticed:

**Before json.dumps()**
{'count': 1, 'meta': {}, 'results': [OrderedDict([(u'LAT', Decimal('14.8263245676')), (u'LNG', Decimal('-89.4853961532'))])]}

**After json.dumps()**
{"count": 1, "meta": {}, "results": [{"LAT": null, "LNG": null}]}

So converting Decimal() class object into String() makes it work.

Cheers,