### PR TITLE
import decimal module

### DIFF
--- a/dataset/freeze/format/fjson.py
+++ b/dataset/freeze/format/fjson.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime, date
 from collections import defaultdict
+from decimal import Decimal
 
 from six import PY3
 


### PR DESCRIPTION
Hi,

Sorry for the mistake, previous pull request #181 didn't include the Decimal module for handling correctly Decimal() objects.

As discussion is on-going about #181, you may prefer to revert modifications.