### PR TITLE
Order JSON freeze fields deterministically

### DIFF
--- a/dataset/freeze/format/fjson.py
+++ b/dataset/freeze/format/fjson.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime, date
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from decimal import Decimal
 
 from six import PY3
@@ -29,10 +29,10 @@ class JSONSerializer(Serializer):
         if self.mode == 'item':
             result = result[0]
         if self.export.get_bool('wrap', True):
-            result = {
-                'count': len(result),
-                'results': result
-            }
+            result = OrderedDict([
+                ('count', len(result)),
+                ('results', result),
+            ])
             meta = self.export.get('meta', {})
             if meta is not None:
                 result['meta'] = meta


### PR DESCRIPTION
To avoid commits like [this one](https://github.com/paulfurley/experimental-liverpool-planning-data/commit/f0599f87bcd0211b2cff977d008119b6aa267bea) on Python 3