### PR TITLE
Allow Date column type (in addition to existing DateTime type)

### DIFF
--- a/dataset/persistence/util.py
+++ b/dataset/persistence/util.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, date
 try:
     from urlparse import urlparse
 except ImportError:
@@ -9,7 +9,7 @@ try:
 except ImportError:  # pragma: no cover
     from ordereddict import OrderedDict
 
-from sqlalchemy import Integer, UnicodeText, Float, DateTime, Boolean
+from sqlalchemy import Integer, UnicodeText, Float, Date, DateTime, Boolean
 from six import string_types
 
 row_type = OrderedDict
@@ -24,6 +24,8 @@ def guess_type(sample):
         return Float
     elif isinstance(sample, datetime):
         return DateTime
+    elif isinstance(sample, date):
+        return Date
     return UnicodeText
 
 


### PR DESCRIPTION
This is a simple change to allow Date column type (i.e. a raw date without a time) to be guessed from a Python datetime.date type.