### PR TITLE
Check if primary column on first _sync_table call

### DIFF
--- a/dataset/table.py
+++ b/dataset/table.py
@@ -241,7 +241,8 @@ class Table(object):
                                     autoincrement=increment)
                     self._table.append_column(column)
                 for column in columns:
-                    self._table.append_column(column)
+                    if not column.name == self._primary_id:
+                        self._table.append_column(column)
                 self._table.create(self.db.executable, checkfirst=True)
         elif len(columns):
             with self.db.lock:


### PR DESCRIPTION
I was running into the error:

`sqlalchemy.exc.ArgumentError: Trying to redefine primary-key column 'my_key' as a non-primary-key column on table 'my_table'
`

When creating a new table with non-default primary key, this change checks if a column is a primary key column before attempting to add again as non-primary key column.