### PR TITLE
Remove link to old documentation

### DIFF
--- a/docs/_themes/kr/sidebarlogo.html
+++ b/docs/_themes/kr/sidebarlogo.html
@@ -8,7 +8,6 @@
 
 <ul>
     <li><a href="quickstart.html">Quickstart Guide</a></li>
-    <li><a href="freezefile.html">Freezefiles</a></li>
     <li><a href="api.html">API documentation</a></li>
     <li><a href="install.html">Installation</a></li>
 </ul>


### PR DESCRIPTION
Sidebar link no longer relevant after project split of datafreeze.