### PR TITLE
Fix Export Data documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -33,4 +33,11 @@ Table
 Data Export
 -----------
 
-.. autofunction:: dataset.freeze
+
+  **Note:** Data exporting has been extracted into a stand-alone package, datafreeze. See the relevant repository here_.
+
+.. _here: https://github.com/pudo/datafreeze
+
+|
+
+.. autofunction:: datafreeze.freeze

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+datafreeze


### PR DESCRIPTION
This re-adds the generated documentation for the `freeze` function. While I considered removing it since it's a different repo, I think it makes sense to keep it considering there's no docs page setup for the datafreeze repo. View the associated generated [readthedocs here](http://dataset-fork-matthew.readthedocs.io/en/bugfix-data-export-docs/api.html#data-export).