### PR TITLE
In `create_column` docs, signpost the Types class

### DIFF
--- a/dataset/table.py
+++ b/dataset/table.py
@@ -322,6 +322,8 @@ class Table(object):
         ::
 
             table.create_column('created_at', db.types.datetime)
+
+        `type` corresponds to an SQLAlchemy type as described by `dataset.db.Types`
         """
         name = normalize_column_name(name)
         if self.has_column(name):


### PR DESCRIPTION
Thanks again for making this wonderful library.

I just stumbled for a while trying to figure out what's valid for `create_column(..., type)`, since they didn't seem to map exactly onto SQLAlchemy names.

Update the docs to point to the `Type` class which holds that mapping.