### PR TITLE
Support for storing Numpy arrays as LargeBinary objects

### DIFF
--- a/dataset/table.py
+++ b/dataset/table.py
@@ -13,6 +13,8 @@ from dataset.types import Types
 from dataset.util import normalize_column_name, index_name, ensure_tuple
 from dataset.util import DatasetException, ResultIter, QUERY_STEP
 from dataset.util import normalize_table_name
+from dataset.util import ndarray2binary
+from numpy import ndarray
 
 
 log = logging.getLogger(__name__)
@@ -275,7 +277,10 @@ class Table(object):
                 sync_columns.append(Column(name, _type))
                 columns.append(name)
             if name in columns:
-                out[name] = value
+                if ( isinstance(value,ndarray) ):
+                    out[name] = ndarray2binary(value)
+                else:
+                    out[name] = value
         self._sync_table(sync_columns)
         return out
 

--- a/dataset/types.py
+++ b/dataset/types.py
@@ -1,8 +1,9 @@
 from datetime import datetime, date
 
-from sqlalchemy import Integer, UnicodeText, Float, BigInteger
+from sqlalchemy import Integer, UnicodeText, Float, BigInteger, LargeBinary
 from sqlalchemy import Boolean, Date, DateTime, Unicode
 from sqlalchemy.types import TypeEngine
+from numpy import ndarray
 
 
 class Types(object):
@@ -15,6 +16,7 @@ class Types(object):
     boolean = Boolean
     date = Date
     datetime = DateTime
+    blob = LargeBinary
 
     def guess(cls, sample):
         """Given a single sample, guess the column type for the field.
@@ -34,4 +36,6 @@ class Types(object):
             return cls.datetime
         elif isinstance(sample, date):
             return cls.date
+        elif isinstance(sample, ndarray):
+            return cls.blob
         return cls.text

--- a/dataset/util.py
+++ b/dataset/util.py
@@ -16,7 +16,7 @@ class DatasetException(Exception):
 def convert_row(row_type, row):
     if row is None:
         return None
-    return row_type(row.items())
+    return convert_blobs(row_type(row.items()))
 
 
 def iter_result_proxy(rp, step=None):
@@ -124,7 +124,8 @@ def convert_blobs(row):
     """Tries to convert the blob entries into the correct datatypes"""
     for key in row.keys():
         if ( isinstance(row[key],str) ):
-            if ( row[key].find("NUMPY") != -1 ):
+            # Numpy's binary format starts with the "magic" string \x93NUMPY
+            if ( row[key].startswith("\x93NUMPY") ):
                 array = binary2ndarray(row[key])
                 row[key] = array
     return row

--- a/dataset/util.py
+++ b/dataset/util.py
@@ -2,6 +2,8 @@ import six
 from hashlib import sha1
 from collections import OrderedDict, Sequence
 from six.moves.urllib.parse import urlparse
+import io
+import numpy as np
 
 QUERY_STEP = 1000
 row_type = OrderedDict
@@ -102,3 +104,18 @@ def ensure_tuple(obj):
     if isinstance(obj, Sequence) and not isinstance(obj, six.string_types):
         return tuple(obj)
     return obj,
+
+def ndarray2binary(array):
+    """Convert a numpy ndarray to a binary string suited for LargeBinary storage"""
+    if ( not isinstance(array,np.ndarray) ):
+        raise TypeError("The argument has to be a numpy ndarray")
+    out = io.BytesIO()
+    np.save(out,array)
+    out.seek(0)
+    return out.read()
+
+def binary2ndarray(string):
+    """Convert a binary string to ndarray"""
+    data = io.BytesIO(string)
+    data.seek(0)
+    return np.load(data)

--- a/dataset/util.py
+++ b/dataset/util.py
@@ -119,3 +119,12 @@ def binary2ndarray(string):
     data = io.BytesIO(string)
     data.seek(0)
     return np.load(data)
+
+def convert_blobs(row):
+    """Tries to convert the blob entries into the correct datatypes"""
+    for key in row.keys():
+        if ( isinstance(row[key],str) ):
+            if ( row[key].find("NUMPY") != -1 ):
+                array = binary2ndarray(row[key])
+                row[key] = array
+    return row

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -442,19 +442,19 @@ class TableTestCase(unittest.TestCase):
         # Test 1D arrays
         array = rand(10)
         pid = tbl.insert({"numpy_array":array})
-        row = convert_blobs(tbl.find_one(id=pid))
+        row = tbl.find_one(id=pid)
         assert allclose(array,row["numpy_array"])
 
         # Test 2D arrays
         array = rand(10,10)
         pid = tbl.insert({"numpy_array":array})
-        row = convert_blobs(tbl.find_one(id=pid))
+        row = tbl.find_one(id=pid)
         assert allclose(array,row["numpy_array"])
 
         # Verify that update also works
         array = rand(10,10)
         tbl.update({"numpy_array":array,"id":pid},["id"])
-        row = convert_blobs(tbl.find_one(id=pid))
+        row = tbl.find_one(id=pid)
         assert allclose(array,row["numpy_array"])
 
 

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals
 import os
 import unittest
 from datetime import datetime
+from numpy.random import rand
+from numpy import allclose
 
 try:
     from collections import OrderedDict
@@ -13,6 +15,7 @@ from sqlalchemy import FLOAT, INTEGER, TEXT
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError, ArgumentError
 
 from dataset import connect
+from dataset.util import convert_blobs
 
 from .sample_data import TEST_DATA, TEST_CITY_1
 
@@ -432,6 +435,21 @@ class TableTestCase(unittest.TestCase):
     def test_empty_query(self):
         empty = list(self.tbl.find(place='not in data'))
         assert len(empty) == 0, empty
+
+    def test_ndarray(self):
+        tbl = self.tbl
+
+        # Test 1D arrays
+        array = rand(10)
+        pid = tbl.insert({"numpy_array":array})
+        row = convert_blobs(tbl.find_one(id=pid))
+        assert allclose(array,row["numpy_array"])
+
+        # Test 2D arrays
+        array = rand(10,10)
+        pid = tbl.insert({"numpy_array":array})
+        row = convert_blobs(tbl.find_one(id=pid))
+        assert allclose(array,row["numpy_array"])
 
 
 class Constructor(dict):

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -15,7 +15,6 @@ from sqlalchemy import FLOAT, INTEGER, TEXT
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError, ArgumentError
 
 from dataset import connect
-from dataset.util import convert_blobs
 
 from .sample_data import TEST_DATA, TEST_CITY_1
 

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -451,6 +451,12 @@ class TableTestCase(unittest.TestCase):
         row = convert_blobs(tbl.find_one(id=pid))
         assert allclose(array,row["numpy_array"])
 
+        # Verify that update also works
+        array = rand(10,10)
+        tbl.update({"numpy_array":array,"id":pid},["id"])
+        row = convert_blobs(tbl.find_one(id=pid))
+        assert allclose(array,row["numpy_array"])
+
 
 class Constructor(dict):
     """ Very simple low-functionality extension to ``dict`` to


### PR DESCRIPTION
It is useful to be able to store Numpy arrays in as a large binary object in a database. Here is an implementation that uses Numpy's native binary format to convert an array to a binary string and put it into the database. When reading entries from the database, there is a function that checks if the binary string starts with \x93NUMPY (which is the first 6 bytes of any numpy array) and converts the string back to a numpy array.