### PR TITLE
find(): if table doesn't exist, return an iterator

### DIFF
--- a/dataset/table.py
+++ b/dataset/table.py
@@ -446,7 +446,7 @@ class Table(object):
         instead.
         """
         if not self.exists:
-            return []
+            return iter([])
 
         _limit = kwargs.pop('_limit', None)
         _offset = kwargs.pop('_offset', 0)


### PR DESCRIPTION
... rather than `[]`

If a table exists, you can treat the output of `find` as an iterator,
specifically you can call `next(find(...))`:

```
>>> db = dataset.connect('sqlite:///:memory1:')
>>> table = db['table_which_exists']
>>> table.insert({'foo': 'x'})
>>> next(table.find(foo='x'))  # no problem
```

But if the table hasn't been created yet, `find(...)` returns an empty list,
which you can't call `next()` on:

```
>>> db = dataset.connect('sqlite:///:memory2:')
>>> table = db_no_table['table_which_doesnt_exis']
>>> next(table.find(foo='x'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'list' object is not an iterator
```

^^^ rather than a `TypeError`, I'd expect to get a `StopIteration`
exception.