### PR TITLE
removed unused package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
     install_requires=[
         'sqlalchemy >= 1.1.1',
         'alembic >= 0.6.2',
-        'normality >= 0.5.1',
         "six >= 1.11.0"
     ],
     tests_require=[


### PR DESCRIPTION
normality package was unused and caused problems when installing, see #274,problems were caused by the pyicu dependency. Normality was needed before splitting dataset and datafreeze in different packages, now it is no longer needed. Please release a new version soon so dataset can be installed on python docker alpine image easily.