### PR TITLE
Fix bug when UPSERTing a column named 'id'

### DIFF
--- a/dataset/table.py
+++ b/dataset/table.py
@@ -29,8 +29,14 @@ class Table(object):
         self.name = normalize_table_name(table_name)
         self._table = None
         self._indexes = []
-        self._primary_id = primary_id
-        self._primary_type = primary_type
+        if primary_id is not None:
+            self._primary_id = primary_id
+        else:
+            self._primary_id = self.PRIMARY_DEFAULT
+        if primary_type is not None:
+            self._primary_type = primary_type
+        else:
+            self._primary_type = Types.integer
         self._auto_create = auto_create
 
     @property
@@ -235,8 +241,8 @@ class Table(object):
                 if self._primary_id is not False:
                     # This can go wrong on DBMS like MySQL and SQLite where
                     # tables cannot have no columns.
-                    primary_id = self._primary_id or self.PRIMARY_DEFAULT
-                    primary_type = self._primary_type or Types.integer
+                    primary_id = self._primary_id
+                    primary_type = self._primary_type
                     increment = primary_type in [Types.integer, Types.bigint]
                     column = Column(primary_id, primary_type,
                                     primary_key=True,

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -236,6 +236,12 @@ class TableTestCase(unittest.TestCase):
             )
         assert len(self.tbl) == len(TEST_DATA) + 1, len(self.tbl)
 
+    def test_upsert_id(self):
+        table = self.db['banana_with_id']
+        data = dict(id=10, title='I am a banana!')
+        table.upsert(data, ['id'])
+        assert len(table) == 1, len(table)
+
     def test_update_while_iter(self):
         for row in self.tbl:
             row['foo'] = 'bar'


### PR DESCRIPTION
Hi!

I noticed an interesting bug with `Table.upsert`: the example from the [documentation](https://dataset.readthedocs.io/en/latest/api.html?highlight=primary%20key#dataset.Table.upsert) does not work.

The checks that should prevent double creation of index column are not quite working. If `self._primary_id` is set to `None`, then the index column with name `id` is created, yet later we try to create it again: https://github.com/pudo/dataset/blob/master/dataset/table.py#L246. This causes following exception (Python 3.6.7, SQLAlchemy 1.3.0b3):

```(venv) $ python fail.py 
Traceback (most recent call last):
  File "fail.py", line 7, in <module>
    table.upsert(data, ['id'])
  File "/.../dataset/dataset/table.py", line 176, in upsert
    row = self._sync_columns(row, ensure, types=types)
  File "/.../dataset/dataset/table.py", line 281, in _sync_columns
    self._sync_table(sync_columns)
  File "/.../dataset/dataset/table.py", line 247, in _sync_table
    self._table.append_column(column)
  File "/.../dataset/venv/lib/python3.6/site-packages/SQLAlchemy-1.3.0b3-py3.6-linux-x86_64.egg/sqlalchemy/sql/schema.py", line 752, in append_column
    column._set_parent_with_dispatch(self)
  File "/.../dataset/venv/lib/python3.6/site-packages/SQLAlchemy-1.3.0b3-py3.6-linux-x86_64.egg/sqlalchemy/sql/base.py", line 456, in _set_parent_with_dispatch
    self._set_parent(parent)
  File "/.../dataset/venv/lib/python3.6/site-packages/SQLAlchemy-1.3.0b3-py3.6-linux-x86_64.egg/sqlalchemy/sql/schema.py", line 1452, in _set_parent
    % (self.key, table.fullname)
sqlalchemy.exc.ArgumentError: Trying to redefine primary-key column 'id' as a non-primary-key column on table 'table'
```

I added the corresponding testcase.

I see several possible solutions. In this PR I set `self._primary_id` and `self._primary_type` to their default value in `Table.__init__`. This way, they will have valid and meaningful values from the very beginning and throughout the whole program.

Alternative approach is to change them when [creating the table](https://github.com/pudo/dataset/blob/master/dataset/table.py#L238).

Or just make [the check](https://github.com/pudo/dataset/blob/master/dataset/table.py#L246) more robust:

    if not column.name == self._primary_id and not (self._primary_id is None and column.name == self.PRIMARY_DEFAULT):