### PR TITLE
Add missing methods in Table api doc

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -26,7 +26,7 @@ Table
 -----
 
 .. autoclass:: dataset.Table
-   :members: columns, find, find_one, all, count, distinct, insert, insert_ignore, insert_many, update, upsert, delete, create_column, drop_column, create_index, drop
+   :members: columns, find, find_one, all, count, distinct, insert, insert_ignore, insert_many, update, upsert, delete, create_column, create_column_by_example, drop_column, create_index, drop, has_column, has_index
    :special-members: __len__, __iter__
 
 


### PR DESCRIPTION
Some methods are missing in the api doc.

To avoid this the [sphinx-automodapi](https://github.com/astropy/sphinx-automodapi/) is great, it generates automatically the list of methods and attributes.