### PR TITLE
Add support for BigInteger

### DIFF
--- a/dataset/types.py
+++ b/dataset/types.py
@@ -27,7 +27,10 @@ class Types(object):
         if isinstance(sample, bool):
             return cls.boolean
         elif isinstance(sample, int):
-            return cls.integer
+            if sample > 2147483647 or sample < -2147483648:
+                return cls.bigint
+            else:
+                return cls.integer
         elif isinstance(sample, float):
             return cls.float
         elif isinstance(sample, datetime):

--- a/dataset/types.py
+++ b/dataset/types.py
@@ -27,10 +27,7 @@ class Types(object):
         if isinstance(sample, bool):
             return cls.boolean
         elif isinstance(sample, int):
-            if sample > 2147483647 or sample < -2147483648:
-                return cls.bigint
-            else:
-                return cls.integer
+            return cls.bigint
         elif isinstance(sample, float):
             return cls.float
         elif isinstance(sample, datetime):

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -6,7 +6,7 @@ import os
 import unittest
 from datetime import datetime
 
-from sqlalchemy import FLOAT, INTEGER, TEXT, BIGINT
+from sqlalchemy import FLOAT, TEXT, BIGINT
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError, ArgumentError
 
 from dataset import connect
@@ -435,7 +435,7 @@ class TableTestCase(unittest.TestCase):
             tbl.table.c['bar'].type
         tbl.create_column_by_example('bar', 1)
         assert 'bar' in tbl.table.c, tbl.table.c
-        assert isinstance(tbl.table.c['bar'].type, INTEGER), \
+        assert isinstance(tbl.table.c['bar'].type, BIGINT), \
             tbl.table.c['bar'].type
         tbl.create_column_by_example('pippo', 'test')
         assert 'pippo' in tbl.table.c, tbl.table.c

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -6,7 +6,7 @@ import os
 import unittest
 from datetime import datetime
 
-from sqlalchemy import FLOAT, INTEGER, TEXT
+from sqlalchemy import FLOAT, INTEGER, TEXT, BIGINT
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError, ArgumentError
 
 from dataset import connect
@@ -441,6 +441,14 @@ class TableTestCase(unittest.TestCase):
         assert 'pippo' in tbl.table.c, tbl.table.c
         assert isinstance(tbl.table.c['pippo'].type, TEXT), \
             tbl.table.c['pippo'].type
+        tbl.create_column_by_example('bigbar', 11111111111)
+        assert 'bigbar' in tbl.table.c, tbl.table.c
+        assert isinstance(tbl.table.c['bigbar'].type, BIGINT), \
+            tbl.table.c['bigbar'].type
+        tbl.create_column_by_example('littlebar', -11111111111)
+        assert 'littlebar' in tbl.table.c, tbl.table.c
+        assert isinstance(tbl.table.c['littlebar'].type, BIGINT), \
+            tbl.table.c['littlebar'].type
 
     def test_key_order(self):
         res = self.db.query('SELECT temperature, place FROM weather LIMIT 1')


### PR DESCRIPTION
Currently when autocreating a table from sample data, the `guess` method assigns all integers as the Integer type, regardless of its size. This causes problems when autocreating a table with integers larger than 2147483647 or less than -2147483648, as these are beyond the signed range of the Integer type. 

I've added a check to determine if the sample integer is beyond the signed range of the basic Integer type. If that is the case, instead of creating a column with the Integer type it will create a column with the BigInteger type. This will solve the bug where a table is autocreated and then the first insert immediately errors because the integer being inserted is out of range.

This is an error I've gotten before (see below). This PR will solve that error. 
`sqlalchemy.exc.DataError: (psycopg2.errors.NumericValueOutOfRange) integer out of range`