### PR TITLE
Implement update_many, upsert_many and refactor for a 2x speed-up of insert_many

### DIFF
--- a/dataset/table.py
+++ b/dataset/table.py
@@ -139,7 +139,7 @@ class Table(object):
             chunk.append(row)
 
             # Insert when chunk_size is fulfilled or this is the last row
-            if len(chunk) == chunk_size or index == len(row) - 1:
+            if len(chunk) == chunk_size or index == len(rows) - 1:
                 chunk = pad_chunk_columns(chunk, columns)
                 self.table.insert().execute(chunk)
                 chunk = []

--- a/dataset/table.py
+++ b/dataset/table.py
@@ -193,13 +193,13 @@ class Table(object):
 
             # bindparam requires names to not conflict (cannot be "id" for id)
             for key in keys:
-                row[f'_{key}'] = row[f'{key}']
+                row['_%s' % key] = row[key]
 
             # Update when chunk_size is fulfilled or this is the last row
             if len(chunk) == chunk_size or index == len(rows) - 1:
                 stmt = self.table.update(
                     whereclause=and_(
-                        *[self.table.c[k] == bindparam(f'_{k}') for k in keys]
+                        *[self.table.c[k] == bindparam('_%s' % k) for k in keys]
                     ),
                     values={
                         col: bindparam(col, required=False) for col in columns

--- a/dataset/table.py
+++ b/dataset/table.py
@@ -3,7 +3,7 @@ import warnings
 import threading
 
 from sqlalchemy.sql import and_, expression
-from sqlalchemy.sql.expression import ClauseElement
+from sqlalchemy.sql.expression import bindparam, ClauseElement
 from sqlalchemy.schema import Column, Index
 from sqlalchemy import func, select, false
 from sqlalchemy.schema import Table as SQLATable
@@ -163,6 +163,51 @@ class Table(object):
         if return_count:
             return self.count(clause)
 
+    def update_many(self, rows, keys, chunk_size=1000, ensure=None, types=None):
+        """Update many rows in the table at a time.
+
+        This is significantly faster than updating them one by one. Per default
+        the rows are processed in chunks of 1000 per commit, unless you specify
+        a different ``chunk_size``.
+
+        See :py:meth:`update() <dataset.Table.update>` for details on
+        the other parameters.
+        """
+        chunk = []
+        columns = set()
+        for row in rows:
+            chunk.append(row)
+            columns = columns.union(set(row.keys()))
+
+            # bindparam requires names to not conflict (cannot be "id" for id)
+            for key in keys:
+                row[f'_{key}'] = row[f'{key}']
+
+            if len(chunk) == chunk_size:
+                stmt = self.table.update(
+                    whereclause=and_(
+                        *[self.table.c[key] == bindparam(f'_{key}') for key in keys]
+                    ),
+                    values={
+                        column: bindparam(column, required=False) for column in columns
+                    }
+                )
+                self.db.executable.execute(stmt, chunk)
+                chunk = []
+                columns = set()
+
+        if len(chunk):
+            stmt = self.table.update(
+                whereclause=and_(
+                    *[self.table.c[key] == bindparam(f'_{key}') for key in keys]
+                ),
+                values={
+                    column: bindparam(column, required=False) for column in columns
+                }
+            )
+            self.db.executable.execute(stmt, chunk)
+
+
     def upsert(self, row, keys, ensure=None, types=None):
         """An UPSERT is a smart combination of insert and update.
 
@@ -180,6 +225,34 @@ class Table(object):
         if row_count == 0:
             return self.insert(row, ensure=False)
         return True
+
+    def upsert_many(self, rows, keys, chunk_size=1000, ensure=None, types=None):
+        """
+        Sorts multiple input rows into upserts and inserts. Inserts are passed
+        to insert_many and upserts are updated.
+
+        See :py:meth:`upsert() <dataset.Table.upsert>` and
+        :py:meth:`insert_many() <dataset.Table.insert_many>`.
+        """
+        # Convert keys to a list if not a list or tuple.
+        keys = keys if type(keys) in (list, tuple) else [keys]
+
+        to_insert = []
+        to_update = []
+        for row in rows:
+            if self.find_one(**{key: row.get(key) for key in keys}):
+                # Row exists - update it.
+                to_update.append(row)
+            else:
+                # Row doesn't exist - insert it.
+                to_insert.append(row)
+
+        # Insert non-existing rows.
+        self.insert_many(to_insert, chunk_size, ensure, types)
+
+        # Update existing rows.
+        self.update_many(to_update, keys, chunk_size, ensure, types)
+
 
     def delete(self, *clauses, **filters):
         """Delete rows from the table.

--- a/dataset/util.py
+++ b/dataset/util.py
@@ -108,12 +108,9 @@ def ensure_tuple(obj):
     return obj,
 
 
-def pad_chunk_columns(chunk):
+def pad_chunk_columns(chunk, columns):
     """Given a set of items to be inserted, make sure they all have the
     same columns by padding columns with None if they are missing."""
-    columns = set()
-    for record in chunk:
-        columns.update(record.keys())
     for record in chunk:
         for column in columns:
             record.setdefault(column, None)

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -388,8 +388,8 @@ class TableTestCase(unittest.TestCase):
         tbl.upsert_many([dict(age=10), dict(weight=W)], 'id')
         assert tbl.find_one(id=1)['age'] == 10
 
-        tbl.upsert_many([dict(id=1, age=70), dict(id=2, weight=W/2)], 'id')
-        assert tbl.find_one(id=2)['weight'] == W/2
+        tbl.upsert_many([dict(id=1, age=70), dict(id=2, weight=W / 2)], 'id')
+        assert tbl.find_one(id=2)['weight'] == W / 2
 
     def test_drop_operations(self):
         assert self.tbl._table is not None, \

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -368,6 +368,29 @@ class TableTestCase(unittest.TestCase):
         self.tbl.insert_many(data, chunk_size=13)
         assert len(self.tbl) == len(data) + 6
 
+    def test_update_many(self):
+        tbl = self.db['update_many_test']
+        tbl.insert_many([
+            dict(temp=10), dict(temp=20), dict(temp=30)
+        ])
+        tbl.update_many(
+            [dict(id=1, temp=50), dict(id=3, temp=50)], 'id'
+        )
+
+        # Ensure data has been updated.
+        assert tbl.find_one(id=1)['temp'] == tbl.find_one(id=3)['temp']
+
+    def test_upsert_many(self):
+        # Also tests updating on records with different attributes
+        tbl = self.db['upsert_many_test']
+
+        W = 100
+        tbl.upsert_many([dict(age=10), dict(weight=W)], 'id')
+        assert tbl.find_one(id=1)['age'] == 10
+
+        tbl.upsert_many([dict(id=1, age=70), dict(id=2, weight=W/2)], 'id')
+        assert tbl.find_one(id=2)['weight'] == W/2
+
     def test_drop_operations(self):
         assert self.tbl._table is not None, \
             'table shouldn\'t be dropped yet'


### PR DESCRIPTION
This is my first PR - I hope you will accept it! I do understand, however, that it may require modification.

The project I am working on has dataset transactions which could be simplified and sped up by upsert_many, so I decided to attempt implementing it. Whilst doing so, I realised I also had to also implement update_many. After doing so, I started tinkering with the insert_many code and saw that _sync_columns was run on every row, which slows it down to around half-speed. By checking before inserting only, all of the non-existing columns are created and then no checks are required for the rest of the process.

The implementation of update_many is also very fast with 1,000,000 rows (with only one integer field) taking (9.12s) to update with a random integer, 28x faster than updates in a transaction (285.86s) and 30x faster than updates without a transaction (307.95s) in my test.

I also wrote some crude and unimaginative tests to go with the additions.

Closes https://github.com/pudo/dataset/issues/249.
Thanks for this great library!