### PR TITLE
Implement handling of iterator rows

### DIFF
--- a/dataset/util.py
+++ b/dataset/util.py
@@ -121,4 +121,3 @@ def universal_len(obj):
     """Gets count of items from many data types that len doesn't work
     on such as generators and iterators."""
     return sum(1 for _ in obj)
-

--- a/dataset/util.py
+++ b/dataset/util.py
@@ -115,3 +115,10 @@ def pad_chunk_columns(chunk, columns):
         for column in columns:
             record.setdefault(column, None)
     return chunk
+
+
+def universal_len(obj):
+    """Gets count of items from many data types that len doesn't work
+    on such as generators and iterators."""
+    return sum(1 for _ in obj)
+

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -503,6 +503,7 @@ class TableTestCase(unittest.TestCase):
 
         assert tbl.find_one(id=1)['temp'] == 20
 
+
 class Constructor(dict):
     """ Very simple low-functionality extension to ``dict`` to
     provide attribute access to dictionary contents"""

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -489,6 +489,19 @@ class TableTestCase(unittest.TestCase):
         empty = list(self.tbl.find(place='not in data'))
         assert len(empty) == 0, empty
 
+    def test_iterators(self):
+        tbl = self.db['iterators_test']
+        tbl.insert_many(iter([
+            dict(temp=10), dict(temp=20), dict(temp=30)
+        ]))
+
+        assert tbl.find_one(id=1)['temp'] == 10
+
+        tbl.update_many(iter([
+            dict(id=1, temp=20), dict(id=2, temp=30), dict(id=3, temp=40)
+        ]), ['id'])
+
+        assert tbl.find_one(id=1)['temp'] == 20
 
 class Constructor(dict):
     """ Very simple low-functionality extension to ``dict`` to


### PR DESCRIPTION
Updated the input_many and update_many functions so that an iterator rows input will be handled properly, as was mentioned by @pudo in my last pull request (#298). It may be a bit over-complicated, so may require modification. 