### PR TITLE
Implement automatic creation of DBs

### DIFF
--- a/dataset/__init__.py
+++ b/dataset/__init__.py
@@ -15,7 +15,8 @@ __version__ = '1.1.2'
 
 
 def connect(url=None, schema=None, reflect_metadata=True, engine_kwargs=None,
-            reflect_views=True, ensure_schema=True, row_type=row_type):
+            reflect_views=True, ensure_schema=True, row_type=row_type,
+            autocreate_db=False):
     """ Opens a new connection to a database.
 
     *url* can be any valid `SQLAlchemy engine URL`_.  If *url* is not defined
@@ -27,7 +28,8 @@ def connect(url=None, schema=None, reflect_metadata=True, engine_kwargs=None,
     loaded.  Additionally, *engine_kwargs* will be directly passed to
     SQLAlchemy, e.g.  set *engine_kwargs={'pool_recycle': 3600}* will avoid `DB
     connection timeout`_. Set *row_type* to an alternate dict-like class to
-    change the type of container rows are stored in.::
+    change the type of container rows are stored in. For non-SQLite DBs, if you
+    want the DB to be automatically created, set *autocreate_db* to True.::
 
         db = dataset.connect('sqlite:///factbook.db')
 
@@ -39,4 +41,5 @@ def connect(url=None, schema=None, reflect_metadata=True, engine_kwargs=None,
 
     return Database(url, schema=schema, reflect_metadata=reflect_metadata,
                     engine_kwargs=engine_kwargs, reflect_views=reflect_views,
-                    ensure_schema=ensure_schema, row_type=row_type)
+                    ensure_schema=ensure_schema, row_type=row_type,
+                    autocreate_db=autocreate_db)

--- a/dataset/database.py
+++ b/dataset/database.py
@@ -11,6 +11,8 @@ from sqlalchemy.pool import StaticPool
 from sqlalchemy.util import safe_reraise
 from sqlalchemy.engine.reflection import Inspector
 
+from sqlalchemy_utils import database_exists, create_database
+
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
 
@@ -27,7 +29,7 @@ class Database(object):
 
     def __init__(self, url, schema=None, reflect_metadata=True,
                  engine_kwargs=None, reflect_views=True,
-                 ensure_schema=True, row_type=row_type):
+                 ensure_schema=True, row_type=row_type, autocreate_db=False):
         """Configure and connect to the database."""
         if engine_kwargs is None:
             engine_kwargs = {}
@@ -55,6 +57,11 @@ class Database(object):
         self.row_type = row_type
         self.ensure_schema = ensure_schema
         self._tables = {}
+
+        # Create DB it doesn't exist (this is automatic only for SQLite DBs)
+        # ref: https://stackoverflow.com/a/30971098
+        if autocreate_db and not database_exists(self.engine.url):
+            create_database(self.engine.url)
 
     @property
     def executable(self):

--- a/dataset/table.py
+++ b/dataset/table.py
@@ -68,8 +68,7 @@ class Table(object):
             for key in set(row.keys()).difference(set(sync_row.keys())):
                 # Get a sample of the new column(s) from the row.
                 sync_row[key] = row[key]
-        self._sync_columns(sync_row, ensure, types=types)
-        return sync_row.keys()
+        return self._sync_columns(sync_row, ensure, types=types).keys()
 
     def has_column(self, column):
         """Check if a column with the given name exists on this table."""

--- a/dataset/table.py
+++ b/dataset/table.py
@@ -15,6 +15,8 @@ from dataset.util import normalize_column_name, index_name, ensure_tuple
 from dataset.util import DatasetException, ResultIter, QUERY_STEP
 from dataset.util import normalize_table_name, pad_chunk_columns, universal_len
 
+from collections import OrderedDict
+
 
 log = logging.getLogger(__name__)
 
@@ -62,10 +64,10 @@ class Table(object):
         return self.table.columns.keys()
 
     def create_missing_columns(self, rows, ensure, types):
-        sync_row = {}
+        sync_row = OrderedDict()
         for row in rows:
             # Only get non-existing columns.
-            for key in set(row.keys()).difference(set(sync_row.keys())):
+            for key in [k for k in row.keys() if k not in sync_row.keys()]:
                 # Get a sample of the new column(s) from the row.
                 sync_row[key] = row[key]
         return self._sync_columns(sync_row, ensure, types=types).keys()

--- a/dataset/table.py
+++ b/dataset/table.py
@@ -389,6 +389,8 @@ class Table(object):
                 key = list(value.keys())[0]
                 if key in ('like',):
                     clauses.append(self.table.c[column].like(value[key]))
+                elif key in ('ilike',):
+                    clauses.append(self.table.c[column].ilike(value[key]))
                 elif key in ('>', 'gt'):
                     clauses.append(self.table.c[column] > value[key])
                 elif key in ('<', 'lt'):
@@ -397,6 +399,8 @@ class Table(object):
                     clauses.append(self.table.c[column] >= value[key])
                 elif key in ('<=', 'lte'):
                     clauses.append(self.table.c[column] <= value[key])
+                elif key in ('=', '==', 'is'):
+                    clauses.append(self.table.c[column] == value[key])
                 elif key in ('!=', '<>', 'not'):
                     clauses.append(self.table.c[column] != value[key])
                 elif key in ('between', '..'):

--- a/dataset/util.py
+++ b/dataset/util.py
@@ -121,4 +121,3 @@ def universal_len(obj):
     """Gets count of items from many data types that len doesn't work
     on such as generators and iterators."""
     return sum(1 for _ in obj)
-

--- a/dataset/util.py
+++ b/dataset/util.py
@@ -115,3 +115,10 @@ def pad_chunk_columns(chunk, columns):
         for column in columns:
             record.setdefault(column, None)
     return chunk
+
+
+def universal_len(obj):
+    """Gets count of items from many data types that len doesn't work
+    on such as generators and iterators."""
+    return sum(1 for _ in obj)
+

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setup(
     install_requires=[
         'sqlalchemy >= 1.1.2',
         'alembic >= 0.6.2',
-        "six >= 1.11.0"
+        "six >= 1.11.0",
+        'sqlalchemy_utils'
     ],
     tests_require=[
         'nose'

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -503,6 +503,7 @@ class TableTestCase(unittest.TestCase):
 
         assert tbl.find_one(id=1)['temp'] == 20
 
+
 class Constructor(dict):
     """ Very simple low-functionality extension to ``dict`` to
     provide attribute access to dictionary contents"""

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -503,6 +503,23 @@ class TableTestCase(unittest.TestCase):
 
         assert tbl.find_one(id=1)['temp'] == 20
 
+    def test_update_unexisting_fields(self):
+        tbl = self.db['update_unexisting_fields']
+        tbl.insert(dict(temp=10))
+        tbl.update(dict(id=1, temp=20, area=3, height=100), 'id')
+
+        # Assert that missing field is synced.
+        assert tbl.find_one(id=1) == dict(id=1, temp=20, area=3, height=100)
+
+    def test_upsert_unexisting_fields(self):
+        tbl = self.db['upsert_unexisting_fields']
+        tbl.insert_many([dict(temp=10), dict(area=3)])
+        tbl.upsert_many([dict(id=1, temp=20), dict(id=2, area=2, day=3)], 'id')
+
+        # Assert that missing fields are synced (NULLED in rows).
+        assert tbl.find_one(id=1) == dict(id=1, area=None, day=None, temp=20)
+        assert tbl.find_one(id=2) == dict(id=2, area=2, day=3, temp=None)
+
 
 class Constructor(dict):
     """ Very simple low-functionality extension to ``dict`` to

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -533,6 +533,7 @@ class TableTestCase(unittest.TestCase):
             assert os.path.exists('autocreate_test.db')
             os.remove('autocreate_test.db')
 
+
 class Constructor(dict):
     """ Very simple low-functionality extension to ``dict`` to
     provide attribute access to dictionary contents"""

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -489,6 +489,7 @@ class TableTestCase(unittest.TestCase):
         empty = list(self.tbl.find(place='not in data'))
         assert len(empty) == 0, empty
 
+<<<<<<< HEAD
     def test_iterators(self):
         tbl = self.db['iterators_test']
         tbl.insert_many(iter([
@@ -520,6 +521,17 @@ class TableTestCase(unittest.TestCase):
         assert tbl.find_one(id=1) == dict(id=1, area=None, day=None, temp=20)
         assert tbl.find_one(id=2) == dict(id=2, area=2, day=3, temp=None)
 
+    def test_database_autocreate(self):
+        # Test only if file doesn't exists to prevent (potential) data loss.
+        # Also cannot test creation of file.
+        msg = 'autocreate_test.db already exists. Stopping test.'
+        exists = os.path.exists('autocreate_test.db')
+        assert not exists, msg
+
+        if not exists:
+            connect('sqlite:///autocreate_test.db', autocreate_db=True)
+            assert os.path.exists('autocreate_test.db')
+            os.remove('autocreate_test.db')
 
 class Constructor(dict):
     """ Very simple low-functionality extension to ``dict`` to

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -339,6 +339,10 @@ class TableTestCase(unittest.TestCase):
         assert len(ds) == 5, ds
         ds = list(self.tbl.find(temperature={'between': [5, 8]}))
         assert len(ds) == 3, ds
+        ds = list(self.tbl.find(place={'=': 'G€lway'}))
+        assert len(ds) == 3, ds
+        ds = list(self.tbl.find(place={'ilike': '%LwAy'}))
+        assert len(ds) == 3, ds
 
     def test_offset(self):
         ds = list(self.tbl.find(place=TEST_CITY_1, _offset=1))

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -489,7 +489,6 @@ class TableTestCase(unittest.TestCase):
         empty = list(self.tbl.find(place='not in data'))
         assert len(empty) == 0, empty
 
-<<<<<<< HEAD
     def test_iterators(self):
         tbl = self.db['iterators_test']
         tbl.insert_many(iter([

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -489,6 +489,19 @@ class TableTestCase(unittest.TestCase):
         empty = list(self.tbl.find(place='not in data'))
         assert len(empty) == 0, empty
 
+    def test_iterators(self):
+        tbl = self.db['iterators_test']
+        tbl.insert_many(iter([
+            dict(temp=10), dict(temp=20), dict(temp=30)
+        ]))
+
+        assert tbl.find_one(id=1)['temp'] == 10
+
+        tbl.update_many(iter([
+            dict(id=1, temp=20), dict(id=2, temp=30), dict(id=3, temp=40)
+        ]), ['id'])
+
+        assert tbl.find_one(id=1)['temp'] == 20
 
 class Constructor(dict):
     """ Very simple low-functionality extension to ``dict`` to


### PR DESCRIPTION
This PR implements automatic creation of DB's (for PostgreSQL in my case - I'm aware that SQLite DB's are already automatically created and wanted to have similar functionality for other DBs).

I'm not sure if it is right for dataset or not. If not, I'll implement it on a project-level basis.

NOTE: this adds another required package `sqlalchemy_utils`.