### PR TITLE
Removed freeze from __all__ listing

### DIFF
--- a/dataset/__init__.py
+++ b/dataset/__init__.py
@@ -10,7 +10,7 @@ warnings.filterwarnings(
     "ignore", "Skipping unsupported ALTER for creation of implicit constraint"
 )
 
-__all__ = ["Database", "Table", "freeze", "connect"]
+__all__ = ["Database", "Table", "connect"]
 __version__ = "1.3.2"
 
 


### PR DESCRIPTION
I removed `freeze` from `__all__` listing.
It likely left remained when splitted into datafreeze package.