### PR TITLE
If the database is SQLite, enable WAL

### DIFF
--- a/dataset/__init__.py
+++ b/dataset/__init__.py
@@ -22,6 +22,7 @@ def connect(
     reflect_views=True,
     ensure_schema=True,
     row_type=row_type,
+    sqlite_wal_mode=True,
 ):
     """ Opens a new connection to a database.
 
@@ -57,4 +58,5 @@ def connect(
         reflect_views=reflect_views,
         ensure_schema=ensure_schema,
         row_type=row_type,
+        sqlite_wal_mode=sqlite_wal_mode,
     )


### PR DESCRIPTION
Since 2010, SQLite has supported WAL (Write Ahead Log) mode that supports multi-threaded writes. Without this mode enabled, SQLite throws errors when there are concurrent writes to a database and generally has poorer concurrent performance.  

More background here:
http://www.sqlite.org/wal.html

In this PR, I enabled WAL for non-in-memory SQLite databases. 

See also:
https://github.com/pudo/dataset/issues/239
