### PR TITLE
Added helper method get_or_create database

### DIFF
--- a/dataset/__init__.py
+++ b/dataset/__init__.py
@@ -65,13 +65,23 @@ def get_or_create(url: str, schema: dict) -> Database:
     A helper function to succinctly open a database, and create explicitly-typed columns if needed.
 
     Sample usage:
-        db = get_or_create('sqlite:///my_website.sqlite3', schema={
+        db = dataset.get_or_create('sqlite:///my_website.sqlite3', schema={
             'users': {
                 'primary': ('username', 'string'),
                 'columns': [('age', 'integer'), ('tagline', 'text'), ('url', 'text')],
                 'index': ['url', ['username', 'age']]
             }
         })
+
+    Instead of:
+        db = dataset.connect('sqlite:///my_website.sqlite3')
+        if 'users' not in db:
+            table = db.create_table(users, primary_id='username', primary_type=db.types.string)
+            table.create_column('age', db.types.integer)
+            table.create_column('tagline', db.types.text)
+            table.create_column('url', db.types.text)
+            table.create_index([url])
+            table.create_index(['username', 'age'])
     """
     db = connect(url)
 

--- a/dataset/__init__.py
+++ b/dataset/__init__.py
@@ -68,8 +68,8 @@ def get_or_create(url: str, schema: dict) -> Database:
         db = dataset.get_or_create('sqlite:///my_website.sqlite3', schema={
             'users': {
                 'primary': ('username', 'string'),
-                'columns': [('age', 'integer'), ('tagline', 'text'), ('url', 'text')],
-                'index': ['url', ['username', 'age']]
+                'columns': [('age', 'integer'), ('upvotes', 'integer'), ('tagline', 'text'), ('bio', 'text'), ('url', 'text')],
+                'index': ['url', ['username', 'upvotes'], ['username', 'age']]
             }
         })
 
@@ -78,9 +78,12 @@ def get_or_create(url: str, schema: dict) -> Database:
         if 'users' not in db:
             table = db.create_table(users, primary_id='username', primary_type=db.types.string)
             table.create_column('age', db.types.integer)
+            table.create_column('upvotes', db.types.integer)
             table.create_column('tagline', db.types.text)
+            table.create_column('bio', db.types.text)
             table.create_column('url', db.types.text)
             table.create_index([url])
+            table.create_index(['username', 'upvotes'])
             table.create_index(['username', 'age'])
     """
     db = connect(url)


### PR DESCRIPTION
This PR adds a succinct way for users to create a table with:
- custom primary keys
- explicitly typed fields
- indicies

I've frequently used this helper function in my projects because I've wanted to explicitly specify the field types and reduces the amount of code needed to create a table with the columns and indicies that I wanted. 

This example in the comments best illustrates this. 

With this PR, you can now create a table like this:

```
db = dataset.get_or_create('sqlite:///my_website.sqlite3', schema={
    'users': {
        'primary': ('username', 'string'),
        'columns': [('age', 'integer'), ('upvotes', 'integer'), ('tagline', 'text'), ('bio', 'text'), ('url', 'text')],
        'index': ['url', ['username', 'upvotes'], ['username', 'age']]
    }
})
```

Instead of:

```
db = dataset.connect('sqlite:///my_website.sqlite3')
if 'users' not in db:
    table = db.create_table(users, primary_id='username', primary_type=db.types.string)
    table.create_column('age', db.types.integer)
    table.create_column('upvotes', db.types.integer)
    table.create_column('tagline', db.types.text)
    table.create_column('bio', db.types.text)
    table.create_column('url', db.types.text)
    table.create_index([url])
    table.create_index(['username', 'upvotes'])
    table.create_index(['username', 'age'])
```
