### PR TITLE
Make sure to also close connection

### DIFF
--- a/dataset/database.py
+++ b/dataset/database.py
@@ -158,6 +158,8 @@ class Database(object):
 
     def close(self):
         """Close database connections. Makes this object unusable."""
+        if hasattr(self.local, "conn"):
+          self.local.conn.close()        
         self.engine.dispose()
         self._tables = {}
         self.engine = None


### PR DESCRIPTION
After test and investigate why dataset not release db connection, even after call close() or engine.dispose(), from below note.

https://dataset.readthedocs.io/en/latest/api.html#notes

> Note: dataset uses SQLAlchemy connection pooling when connecting to the database. There is no way of explicitly clearing or shutting down the connections, other than having the dataset instance garbage collected.

I found that because it still has connection open. From [sqlalchemy document](https://docs.sqlalchemy.org/en/13/core/connections.html).

> The Engine.connect() method returns a Connection object, and by using it in a Python context manager (e.g. the with: statement) the Connection.close() method is automatically invoked at the end of the block. 

and [code comment sqlalchemy/engine/base.py#L48](https://github.com/sqlalchemy/sqlalchemy/blob/bd8b269a34153c29c7f05e4acacccc6b07b47fb5/lib/sqlalchemy/engine/base.py#L48)

    The Connection object represents a single DBAPI connection checked out
    from the connection pool. In this state, the connection pool has no affect
    upon the connection, including its expiration or timeout state. For the
    connection pool to properly manage connections, connections should be
    returned to the connection pool (i.e. ``connection.close()``) whenever the
    connection is not in use.

it's need to call .close() for any open connection to make sure connection close. 