### PR TITLE
Fixed connection to database not closing when context manager exits

### DIFF
--- a/dataset/database.py
+++ b/dataset/database.py
@@ -157,6 +157,7 @@ class Database(object):
                     self.rollback()
         else:
             self.rollback()
+        self.close()
 
     def close(self):
         """Close database connections. Makes this object unusable."""


### PR DESCRIPTION
Currently, when a database connection made with a context manager exits, the connection to the database isn't actually closed.

For example, the following code will cause a stock MySQL database to lock up in about 15-20 seconds when it hits 151 simultaneous open connections:

```python
import time

import dataset

while True:
    with dataset.connect("mysql://root:password@127.0.0.1/database") as db:
        table = db["tickets"]
        ticket = table.find_one(user_id=0000000000000000)

    time.sleep(0.1)
```