### PR TITLE
docs: fix broken examples for `find`

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -142,8 +142,8 @@ We can search for specific entries using :py:meth:`find() <dataset.Table.find>` 
    winners = table.find(id=[1, 3, 7])
 
    # Find by comparison operator
-   elderly_users = table.find((age, '>=', 70))
-   possible_customers = table.find((age, 'between', [21, 80]))
+   elderly_users = table.find(age={'>=': 70})
+   possible_customers = table.find(age={'between': [21, 80]})
 
    # Use the underlying SQLAlchemy directly
    elderly_users = table.find(table.table.columns.age >= 70)


### PR DESCRIPTION
With this change the examples now match the format shown in https://github.com/pudo/dataset/blob/master/docs/queries.rst, and now work correctly (right now it will throw `NameError: name `age` is not defined)