### PR TITLE
Allow passing in arbitrary sqlite pragmas

### DIFF
--- a/dataset/__init__.py
+++ b/dataset/__init__.py
@@ -21,6 +21,7 @@ def connect(
     ensure_schema=True,
     row_type=row_type,
     sqlite_wal_mode=True,
+    sqlite_pragmas=None,
 ):
     """Opens a new connection to a database.
 
@@ -39,6 +40,10 @@ def connect(
     the `ensure_schema` argument. It can also be overridden in a lot of the
     data manipulation methods using the `ensure` flag.
 
+    If you want to run custom SQLite pragmas on database connect, you can add them to sqlite_pragmas
+    You can view a full list of PRAGMAs here:
+    https://www.sqlite.org/pragma.html
+
     .. _SQLAlchemy Engine URL: http://docs.sqlalchemy.org/en/latest/core/engines.html#sqlalchemy.create_engine
     .. _DB connection timeout: http://docs.sqlalchemy.org/en/latest/core/pooling.html#setting-pool-recycle
     """
@@ -52,4 +57,5 @@ def connect(
         ensure_schema=ensure_schema,
         row_type=row_type,
         sqlite_wal_mode=sqlite_wal_mode,
+        sqlite_pragmas=sqlite_pragmas,
     )


### PR DESCRIPTION
SQLite has many PRAGMA statements that can help increase performance, but almost all of them require using pramas:
- disable synchronous commits: `PRAGMA synchronous = OFF`
- journal in-memory instead of on-disk:`PRAGMA journal_mode = MEMORY`
- use mmap: `pragma mmap_size = <bytes>;`
- increase page size: `pragma page_size = <bytes>;`
- WAL (already available in dataset): `pragma journal_mode = WAL;`

There are many other pragmas that allow further tuning of SQLite. 

However, there is no easy way right now to pass in these PRAGMAs when SQLite is opened. With this PR, we re-use the functionality of passing in pragmas on database creation (which we currently use for WAL), but extend this to support all PRAGMAs.

sources:
https://stackoverflow.com/questions/1711631/improve-insert-per-second-performance-of-sqlite
https://blog.devart.com/increasing-sqlite-performance.html


