### PR TITLE
fix: Handle list type as JSON.

### DIFF
--- a/dataset/types.py
+++ b/dataset/types.py
@@ -43,4 +43,6 @@ class Types(object):
             return self.date
         elif isinstance(sample, dict):
             return self.json
+        elif isinstance(sample, list):
+            return self.json
         return self.text

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -198,6 +198,10 @@ class TableTestCase(unittest.TestCase):
                     "language": "German",
                     "population": 3292365,
                 },
+                "largest_cities": [
+                    "Berlin",
+                    "Hamburg",
+                ]
             }
         )
         assert len(self.tbl) == len(TEST_DATA) + 1, len(self.tbl)


### PR DESCRIPTION
Before this change, if you had a list of data, it would be inferred as
text type.  Then when we try to insert data, we would  get the following
error:

sqlite3.InterfaceError: Error binding parameter 4 - probably unsupported type.

Handling lists as JSON type resolves this error.