### PR TITLE
docs: Fix a few typos

### DIFF
--- a/dataset/table.py
+++ b/dataset/table.py
@@ -717,7 +717,7 @@ class Table(object):
     def __iter__(self):
         """Return all rows of the table as simple dictionaries.
 
-        Allows for iterating over all rows in the table without explicetly
+        Allows for iterating over all rows in the table without explicitly
         calling :py:meth:`find() <dataset.Table.find>`.
         ::
 

--- a/docs/queries.rst
+++ b/docs/queries.rst
@@ -62,7 +62,7 @@ Queries using raw SQL
 
 To run more complex queries with JOINs, or to perform GROUP BY-style
 aggregation, you can also use :py:meth:`db.query() <dataset.Database.query>`
-to run raw SQL queries instead. This also supports paramterisation to avoid
+to run raw SQL queries instead. This also supports parameterisation to avoid
 SQL injections.
 
 Finally, you should consider falling back to SQLAlchemy_ core to construct

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -208,7 +208,7 @@ considered out of scope for the project, include:
 * Support for Python 2.x
 
 There's also some functionality that might be cool to support in the future, but
-that requires signficant engineering:
+that requires significant engineering:
 
 * Async operations
 * Database-native ``UPSERT`` semantics


### PR DESCRIPTION
There are small typos in:
- dataset/table.py
- docs/queries.rst
- docs/quickstart.rst

Fixes:
- Should read `significant` rather than `signficant`.
- Should read `parameterisation` rather than `paramterisation`.
- Should read `explicitly` rather than `explicetly`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md