### PR TITLE
fix update_many with new columns

### DIFF
--- a/dataset/table.py
+++ b/dataset/table.py
@@ -223,6 +223,13 @@ class Table(object):
         See :py:meth:`update() <dataset.Table.update>` for details on
         the other parameters.
         """
+        # Create a dummy row containing all possible columns just for schema sync
+        sync_row = {}
+        for row in rows:
+            sync_row.update({k:v for k,v in row.items() if k not in sync_row})
+
+        self._sync_columns(sync_row, ensure, types=types)
+
         keys = ensure_list(keys)
 
         chunk = []
@@ -234,8 +241,7 @@ class Table(object):
 
             # bindparam requires names to not conflict (cannot be "id" for id)
             for key in keys:
-                row["_%s" % key] = row[key]
-                row.pop(key)
+                row[f"_{key}"] = row.pop(key)
             chunk.append(row)
 
             # Update when chunk_size is fulfilled or this is the last row


### PR DESCRIPTION
fixes a bug where updating many records with new columns and ensuring those columns are created would raise a `sqlalchemy.exc.CompileError` exception as reported in #409

the pull request includes two new unit-tests:
1. _ensure_ the bug is fixed
2. demonstrate the behaviour when new columns are present but the `ensure` argument is set to `False`

in making these changes i did not consider the cases under point 2, i'm uncertain what the right behaviour should be under those circumstances

as stated by @4l1fe in #409 this solution may work on other methods

> a way to improve the insert_many(), upsert_many(), update_many() methods is to add a new wrapper _sync_columns_many()

i wouldn't mind working on this if there is some indication the work will get merged
ping @pudo, @gka