### PR TITLE
Fix update_many column synchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ changes must be reconstructed from revision history.*
   - **`insert`/`insert_ignore`/`upsert`**: Return type changed from `int | bool` to `Any` (primary keys can be any type)
   - **Removed `banal` dependency**: Replaced `ensure_list` with typed `ensure_strings` utility
   - **`update_many`**: Fixed mutation of input rows — rows are now copied before modification
+  - **Bulk writes**: Synchronize missing columns before `update_many` and consistently ignore unknown columns when `ensure=False`
   - **Dev tooling**: Added `mypy` to dev dependencies, `make lint` now runs both ruff and mypy
   - **Build system**: Migrated from setuptools to modern pyproject.toml with Hatchling (PEP 621)
   - **Linting**: Replaced flake8 with ruff for faster, more comprehensive linting

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,6 +191,8 @@ The codebase passes both ruff and `mypy --strict` with zero errors.
 - `insert`/`insert_ignore`/`upsert` return `Any` (primary keys can be any type)
 - `primary_type` parameter typed as `ColumnType` instead of `Types`
 - `update_many` no longer mutates input rows
+- Bulk inserts and updates synchronize columns represented anywhere in the batch;
+  `ensure=False` ignores unknown columns consistently with single-row writes
 
 ### Modern Build System (v1.7+)
 - Migrated from setuptools to Hatchling with pyproject.toml (PEP 621)

--- a/dataset/table.py
+++ b/dataset/table.py
@@ -213,22 +213,18 @@ class Table:
             rows = [dict(name='Dolly')] * 10000
             table.insert_many(rows)
         """
-        # Sync table before inputting rows.
-        sync_row: MutableRow = {}
-        for row in rows:
-            # Only get non-existing columns.
-            sync_keys = list(sync_row.keys())
-            for key in [k for k in row if k not in sync_keys]:
-                # Get a sample of the new column(s) from the row.
-                sync_row[key] = row[key]
-        self._sync_columns(sync_row, ensure, types=types)
-
-        # Get columns name list to be used for padding later.
-        columns = sync_row.keys()
+        columns = self._sync_columns_many(rows, ensure, types=types)
+        column_set = set(columns)
 
         chunk: list[MutableRow] = []
         for index, row in enumerate(rows):
-            chunk.append(dict(row))
+            chunk.append(
+                {
+                    self._get_column_name(key): value
+                    for key, value in row.items()
+                    if self._get_column_name(key) in column_set
+                }
+            )
 
             # Insert when chunk_size is fulfilled or this is the last row
             if len(chunk) == chunk_size or index == len(rows) - 1:
@@ -292,17 +288,19 @@ class Table:
         See :py:meth:`update() <dataset.Table.update>` for details on
         the other parameters.
         """
-        keys = ensure_strings(keys)
+        columns = self._sync_columns_many(rows, ensure, types=types)
+        keys = [self._get_column_name(key) for key in ensure_strings(keys)]
+        column_set = set(columns)
+        update_columns = [column for column in columns if column not in keys]
 
         chunk: list[MutableRow] = []
-        columns: list[str] = []
         for index, row in enumerate(rows):
-            columns.extend(
-                col for col in row if (col not in columns) and (col not in keys)
-            )
-
             # bindparam requires names to not conflict (cannot be "id" for id)
-            row_ = dict(row)
+            row_ = {
+                self._get_column_name(key): value
+                for key, value in row.items()
+                if self._get_column_name(key) in column_set
+            }
             for key in keys:
                 row_[f"_{key}"] = row_[key]
                 row_.pop(key)
@@ -311,11 +309,10 @@ class Table:
             # Update when chunk_size is fulfilled or this is the last row
             if len(chunk) == chunk_size or index == len(rows) - 1:
                 cl = [self.table.c[k] == bindparam(f"_{k}") for k in keys]
-                stmt = (
-                    self.table.update()
-                    .where(and_(True, *cl))
-                    .values({col: bindparam(col, required=False) for col in columns})
-                )
+                values: dict[str, Any] = {
+                    col: bindparam(col, required=False) for col in update_columns
+                }
+                stmt = self.table.update().where(and_(True, *cl)).values(values)
                 self.db.executable.execute(stmt, chunk)
                 self.db._auto_commit()
                 chunk = []
@@ -482,6 +479,19 @@ class Table:
                 out[name] = value
         self._sync_table(list(sync_columns.values()))
         return out
+
+    def _sync_columns_many(
+        self,
+        rows: Sequence[WriteRow],
+        ensure: bool | None,
+        types: dict[str, ColumnType] | None = None,
+    ) -> list[str]:
+        """Synchronize every column represented in a batch of rows."""
+        samples: MutableRow = {}
+        for row in rows:
+            for key, value in row.items():
+                samples.setdefault(key, value)
+        return list(self._sync_columns(samples, ensure, types=types))
 
     def _check_ensure(self, ensure: bool | None) -> bool:
         if ensure is None:

--- a/test/test_table.py
+++ b/test/test_table.py
@@ -321,6 +321,36 @@ def test_update_many(db):
     assert tbl.find_one(id=1)["temp"] == tbl.find_one(id=3)["temp"]
 
 
+def test_update_many_creates_missing_columns(db):
+    tbl = db["update_many_new_columns"]
+    tbl.insert_many([{"name": "one"}, {"name": "two"}])
+
+    tbl.update_many(
+        [
+            {"id": 1, "score": 10},
+            {"id": 2, "label": "second"},
+        ],
+        "id",
+    )
+
+    assert tbl.find_one(id=1)["score"] == 10
+    assert tbl.find_one(id=2)["label"] == "second"
+
+
+def test_update_many_without_ensure_ignores_missing_columns(db):
+    tbl = db["update_many_existing_columns"]
+    tbl.insert({"name": "one"})
+
+    tbl.update_many(
+        [{"id": 1, "name": "updated", "missing": "ignored"}],
+        "id",
+        ensure=False,
+    )
+
+    assert tbl.find_one(id=1)["name"] == "updated"
+    assert "missing" not in tbl.columns
+
+
 def test_chunked_update(db):
     tbl = db["update_many_test"]
     tbl.insert_many(


### PR DESCRIPTION
Fixes #409.

- Synchronize every column represented in a bulk-write batch before executing it.
- Apply `ensure=False` consistently by dropping unknown fields from bulk rows.
- Keep input row mappings unchanged.

Validation: 63 tests pass; Ruff, strict mypy, diff checks, and package build pass.
