### PR TITLE
Warn on set filters containing operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ changes must be reconstructed from revision history.*
   - **New types**: Exported `OutRow`, `RowFactory`, `QueryError` for downstream use
   - **`RowFactory`**: The `row_type` parameter is now typed as `Callable[[Iterable[tuple[str, Any]]], OutRow]` instead of `type`
   - **`QueryError`**: New exception subclass of `DatasetError` for invalid filter operations
+  - **Filter typo warning**: Set-valued filters containing an advanced operator now emit a `SyntaxWarning`
   - **`primary_type`**: Changed from `Types` to `ColumnType` (SQLAlchemy `TypeEngine`) — the actual accepted type
   - **`insert`/`insert_ignore`/`upsert`**: Return type changed from `int | bool` to `Any` (primary keys can be any type)
   - **Removed `banal` dependency**: Replaced `ensure_list` with typed `ensure_strings` utility

--- a/dataset/table.py
+++ b/dataset/table.py
@@ -39,6 +39,35 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
+_ADVANCED_FILTER_OPERATORS = frozenset(
+    {
+        "like",
+        "ilike",
+        "notlike",
+        "notilike",
+        ">",
+        "gt",
+        "<",
+        "lt",
+        ">=",
+        "gte",
+        "<=",
+        "lte",
+        "=",
+        "==",
+        "is",
+        "!=",
+        "<>",
+        "not",
+        "in",
+        "notin",
+        "between",
+        "..",
+        "startswith",
+        "endswith",
+    }
+)
+
 
 class Table:
     """Represents a table in a database and exposes common operations."""
@@ -542,6 +571,17 @@ class Table:
         clauses = list(clauses)
         for column, value in args.items():
             column = self._get_column_name(column)
+            if isinstance(value, set):
+                operators = sorted(value.intersection(_ADVANCED_FILTER_OPERATORS))
+                if operators:
+                    warnings.warn(
+                        f"Set-valued filter for {column!r} contains advanced "
+                        f"operator(s) {', '.join(map(repr, operators))}. Sets are "
+                        "interpreted as IN queries; use a mapping for an advanced "
+                        "filter.",
+                        SyntaxWarning,
+                        stacklevel=3,
+                    )
             if not self.has_column(column):
                 clauses.append(false())
             elif isinstance(value, (list, tuple, set)):

--- a/docs/queries.rst
+++ b/docs/queries.rst
@@ -23,6 +23,10 @@ A special form is using keyword searches on specific columns::
     # equal to:
     results = table.find(value={'in': ('foo', 'bar')})
 
+Because sets are also valid ``IN`` filters, a set containing an advanced-filter
+operator emits a ``SyntaxWarning``. This catches a common typo such as
+``value={'<=', 10}``; write ``value={'<=': 10}`` for the advanced-filter form.
+
 The following comparison operators are supported:
 
 ============== ============================================================

--- a/test/test_table.py
+++ b/test/test_table.py
@@ -1,3 +1,4 @@
+import warnings
 from datetime import datetime
 
 import pytest
@@ -216,6 +217,48 @@ def test_find_dsl(table):
     assert len(ds) == 3, ds
     ds = list(table.find(place={"ilike": "%LwAy"}))
     assert len(ds) == 3, ds
+
+
+@pytest.mark.parametrize(
+    "operator",
+    [
+        "like",
+        "ilike",
+        "notlike",
+        "notilike",
+        ">",
+        "gt",
+        "<",
+        "lt",
+        ">=",
+        "gte",
+        "<=",
+        "lte",
+        "=",
+        "==",
+        "is",
+        "!=",
+        "<>",
+        "not",
+        "in",
+        "notin",
+        "between",
+        "..",
+        "startswith",
+        "endswith",
+    ],
+)
+def test_find_warns_for_operators_in_set_filters(table, operator):
+    with pytest.warns(SyntaxWarning, match="Sets are interpreted as IN queries"):
+        list(table.find(temperature={operator, 5}))
+
+
+def test_find_does_not_warn_for_ordinary_set_filters(table):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        rows = list(table.find(temperature={5, 8}))
+    assert not [warning for warning in caught if warning.category is SyntaxWarning]
+    assert len(rows) == 2
 
 
 def test_startswith_endswith(db):


### PR DESCRIPTION
Closes #421.

Set-valued filters remain supported as `IN` queries, but they now emit a `SyntaxWarning` when they contain a recognized advanced-filter operator. This catches mistakes such as `value={'<=', 10}` while preserving ordinary set filters.

Validation: 86 tests pass; Ruff and strict mypy pass; package and Sphinx `-W` builds pass. The current Ruff formatter reports the same two pre-existing formatting differences as `upstream/main`.
