### PR TITLE
feat: add find column projection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,8 @@ dataset/
 - **update()**: Update rows matching keys
 - **upsert()**: Insert or update based on key columns
 - **delete()**: Delete rows matching filters
-- **find()**: Query with filters, ordering, limit/offset
-- **find_one()**: Return single row or None
+- **find()**: Query with filters, ordering, limit/offset, and optional `_columns` projection
+- **find_one()**: Return one full or `_columns`-projected row, or None
 
 ### 4. Transaction Support
 - Context manager: `with dataset.connect() as tx:`

--- a/dataset/table.py
+++ b/dataset/table.py
@@ -721,6 +721,7 @@ class Table:
         _limit: int | None = None,
         _offset: int = 0,
         order_by: str | Sequence[str] | None = None,
+        _columns: str | Sequence[str] | None = None,
         _streamed: bool = False,
         _step: int | None = QUERY_STEP,
         **kwargs: SQLWriteValue,
@@ -746,6 +747,10 @@ class Table:
             # return all rows sorted by multiple columns (descending by year)
             results = table.find(order_by=['country', '-year'])
 
+        Use ``_columns`` to return only selected columns::
+
+            results = table.find(country='France', _columns=['name', 'year'])
+
         You can also submit filters based on criteria other than equality,
         see :ref:`advanced_filters` for details.
 
@@ -763,7 +768,20 @@ class Table:
 
         orderings = self._args_to_order_by(order_by)
         args = self._args_to_clause(kwargs, clauses=_clauses)
-        query = self.table.select().where(args).limit(_limit).offset(_offset)
+        if _columns is None:
+            query = self.table.select()
+        else:
+            column_names = ensure_strings(_columns)
+            if not column_names:
+                raise QueryError("_columns must contain at least one column")
+            selected = []
+            for column in column_names:
+                column = self._get_column_name(column)
+                if not self.has_column(column):
+                    raise QueryError(f"Unknown selected column: {column}")
+                selected.append(self.table.c[column])
+            query = select(*selected)
+        query = query.where(args).limit(_limit).offset(_offset)
         if len(orderings):
             query = query.order_by(*orderings)
 
@@ -781,7 +799,10 @@ class Table:
         )
 
     def find_one(
-        self, *args: ColumnElement[bool], **kwargs: SQLWriteValue
+        self,
+        *args: ColumnElement[bool],
+        _columns: str | Sequence[str] | None = None,
+        **kwargs: SQLWriteValue,
     ) -> OutRow | None:
         """Get a single result from the table.
 
@@ -794,7 +815,9 @@ class Table:
         if not self.exists:
             return None
 
-        resiter = self.find(*args, _limit=1, _step=None, **kwargs)  # type: ignore[arg-type]
+        resiter = self.find(
+            *args, _limit=1, _step=None, _columns=_columns, **kwargs  # type: ignore[arg-type]
+        )
         try:
             for row in resiter:
                 return row

--- a/docs/queries.rst
+++ b/docs/queries.rst
@@ -45,6 +45,19 @@ endswith       String ends with
 Querying for a specific value on a column that does not exist on the table
 will return no results.
 
+To return only specific columns, pass a column name or sequence of column names
+using ``_columns``. Filtering and ordering may still use columns that are not
+part of the returned row::
+
+    results = table.find(
+        country='Germany',
+        _columns=['name', 'city'],
+        order_by='name',
+    )
+    row = table.find_one(id=42, _columns='name')
+
+Unknown or empty column selections raise :py:class:`dataset.QueryError`.
+
 You can also pass `SQLAlchemy core expressions`_ directly into the
 :py:meth:`table.find() <dataset.Table.find>` method as positional arguments.
 Access the underlying SQLAlchemy table via ``table.table`` and its columns

--- a/test/test_table.py
+++ b/test/test_table.py
@@ -4,7 +4,7 @@ import pytest
 from sqlalchemy.exc import ArgumentError
 from sqlalchemy.types import BIGINT, TEXT
 
-from dataset import chunked
+from dataset import QueryError, chunked
 
 from .conftest import TEST_CITY_1, TEST_DATA
 
@@ -195,6 +195,32 @@ def test_find(table):
     assert ds[0]["temperature"] == 8, ds
     ds = list(table.find(table.table.columns.temperature > 4))
     assert len(ds) == 3, ds
+
+
+def test_find_column_projection(table):
+    rows = list(
+        table.find(
+            place=TEST_CITY_1,
+            _columns=["place", "temperature"],
+            order_by="temperature",
+        )
+    )
+    assert [list(row) for row in rows] == [
+        ["place", "temperature"],
+        ["place", "temperature"],
+        ["place", "temperature"],
+    ]
+    assert [row["temperature"] for row in rows] == [5, 6, 8]
+
+    row = table.find_one(place=TEST_CITY_1, _columns="temperature")
+    assert row is not None
+    assert list(row) == ["temperature"]
+
+
+@pytest.mark.parametrize("columns", [[], ["missing"]])
+def test_find_rejects_invalid_column_projection(table, columns):
+    with pytest.raises(QueryError):
+        list(table.find(_columns=columns))
 
 
 def test_find_dsl(table):


### PR DESCRIPTION
Adds `_columns` projection to `find` and `find_one`, including validation for empty or unknown selections. Filtering and ordering can still use unreturned columns.

Fixes #432

Tests: 64 passed; Ruff, strict mypy, wheel, and Sphinx `-W` builds pass.
